### PR TITLE
Updated regexp to not accept 000x as last digits. Updated xunit to la…

### DIFF
--- a/Personnummer.Tests/Personnummer.Tests.csproj
+++ b/Personnummer.Tests/Personnummer.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -160,7 +160,7 @@ namespace Personnummer
         }
 
         #region Static internal.
-        private static readonly Regex regex = new Regex(@"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\+\-\s]?)(\d{3})(\d)$");
+        private static readonly Regex regex = new Regex(@"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\+\-\s]?)((?!000)\d{3})(\d)$");
 
         private static int Luhn(string value)
         {


### PR DESCRIPTION
…test.

**Type of change**

- [ ] New feature
- [X] Bug fix
- [X] Security patch
- [ ] Documentation update

**Description**

Fixes a minor regexp issue where 000\d was accepted as last 4 digits, which is incorrect by personnummer standard.


**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
