### PR TITLE
Add format option to ignore the separator

### DIFF
--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -268,6 +268,27 @@ namespace Personnummer.Tests
             Assert.Equal(sep, Personnummer.Parse(ssn.SeparatedFormat, new Personnummer.Options { AllowCoordinationNumber = true }).Separator);
             // Getting the separator from a short formatted none-separated person number is not actually possible if it is intended to be a +.
         }
+        
+        [Theory]
+        [ClassData(typeof(ValidSsnDataProvider))]
+        [ClassData(typeof(ValidCnDataProvider))]
+        public void TestIgnoreSeparatorWhenFormatting(PersonnummerData ssn)
+        {
+            var separators = "+-".ToCharArray();
+            
+            var ps1 = Personnummer.Parse(ssn.LongFormat, new Personnummer.Options { AllowCoordinationNumber = true });
+            var ps2 = Personnummer.Parse(ssn.SeparatedLong, new Personnummer.Options { AllowCoordinationNumber = true });
+            var ps3 = Personnummer.Parse(ssn.SeparatedFormat,
+                new Personnummer.Options { AllowCoordinationNumber = true });
+            
+            Assert.True(ps1.Format(false, true).IndexOfAny(separators) == -1);
+            Assert.True(ps2.Format(false, true).IndexOfAny(separators) == -1);
+            Assert.True(ps3.Format(false, true).IndexOfAny(separators) == -1);
+            
+            Assert.True(ps1.Format().IndexOfAny(separators) >= 0);
+            Assert.True(ps2.Format().IndexOfAny(separators) >= 0);
+            Assert.True(ps3.Format().IndexOfAny(separators) >= 0);
+        }
 
         [Theory]
         [ClassData(typeof(OrgNumberDataProvider))]

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -126,10 +126,11 @@ namespace Personnummer
         /// If longFormat is true, it will include the century (YYYYMMDD-/+XXXX)
         /// </summary>
         /// <param name="longFormat">If century should be included.</param>
+        /// <param name="ignoreSeparator">Whether the separator should be ignored.</param>
         /// <returns>Formatted personal identity number.</returns>
-        public string Format(bool longFormat = false)
+        public string Format(bool longFormat = false, bool ignoreSeparator = false)
         {
-            return $"{(longFormat ? FullYear : Year)}{Month}{Day}{Separator}{Numbers}";
+            return ignoreSeparator ? $"{(longFormat ? FullYear : Year)}{Month}{Day}{Numbers}" : $"{(longFormat ? FullYear : Year)}{Month}{Day}{Separator}{Numbers}";
         }
 
         /// <summary>


### PR DESCRIPTION
**Note**

The examples in the readme file are not correct, there the separator is not including but in the current version it is always included. Didn't want to change that part, but maybe worth updating?
*(this was an issue before and is not introduced by this PR)*

**Type of change**

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Adds the option to format the person number without a separator.

**Related issue**

None.

**Motivation**

Useful for some cases :)

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
- [x] New tests added which covers the added code.
- [x] Documentation is updated.
- [ ] This PR includes breaking changes.
