### PR TITLE
Add function to validate personal identity number according to select…

### DIFF
--- a/Personnummer.Tests/DataProvider.cs
+++ b/Personnummer.Tests/DataProvider.cs
@@ -142,6 +142,30 @@ namespace Personnummer.Tests
         }
     }
 
+    public class ValidFormatSsnDataProvider : SsnDataProvider
+    {
+        public override IEnumerator<object[]> GetEnumerator()
+        {
+            var json = @"[{        ""integer"": 199305269996,        ""long_format"": ""199305269996"",        ""short_format"": ""9305269996"",        ""separated_format"": ""930526-9996"",        ""separated_long"": ""19930526-9996"",        ""valid"": true,        ""type"": ""ssn"",        ""isMale"": true,        ""isFemale"": false    }]";
+
+            var data = JsonConvert.DeserializeObject<List<PersonnummerData>>(json);
+
+            return data.Select(x => new object[] {x}).GetEnumerator();
+        }
+    }
+
+    public class InvalidFormatSsnDataProvider : SsnDataProvider
+    {
+        public override IEnumerator<object[]> GetEnumerator()
+        {
+            var json = @"[{        ""integer"": 199305269996,        ""long_format"": ""9305269996"",        ""short_format"": ""199305269996"",        ""separated_format"": ""19930526-9996"",        ""separated_long"": ""930526-9996"",        ""valid"": true,        ""type"": ""ssn"",        ""isMale"": true,        ""isFemale"": false    }]";
+
+            var data = JsonConvert.DeserializeObject<List<PersonnummerData>>(json);
+
+            return data.Select(x => new object[] { x }).GetEnumerator();
+        }
+    }
+
     public class InvalidSsnDataProvider : SsnDataProvider
     {
         public override IEnumerator<object[]> GetEnumerator()

--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -242,6 +242,26 @@ namespace Personnummer.Tests
         }
 
         [Theory]
+        [ClassData(typeof(InvalidFormatSsnDataProvider))]
+        public void TestValidFailFormat(PersonnummerData ssn)
+        {
+            Assert.False(Personnummer.ValidFormat(ssn.LongFormat, true, true));
+            Assert.False(Personnummer.ValidFormat(ssn.SeparatedLong, true, false));
+            Assert.False(Personnummer.ValidFormat(ssn.SeparatedFormat, false, false));
+            Assert.False(Personnummer.ValidFormat(ssn.ShortFormat, false, true));
+        }
+
+        [Theory]
+        [ClassData(typeof(ValidFormatSsnDataProvider))]
+        public void TestValidFormat(PersonnummerData ssn)
+        {
+            Assert.True(Personnummer.ValidFormat(ssn.LongFormat, true, true));
+            Assert.True(Personnummer.ValidFormat(ssn.SeparatedLong,true,false));
+            Assert.True(Personnummer.ValidFormat(ssn.SeparatedFormat,false,false));
+            Assert.True(Personnummer.ValidFormat(ssn.ShortFormat,false,true));
+        }
+
+        [Theory]
         [ClassData(typeof(ValidSsnDataProvider))]
         [ClassData(typeof(ValidCnDataProvider))]
         public void TestMaleFemale(PersonnummerData ssn)

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -176,7 +176,7 @@ namespace Personnummer
         {
             try
             {
-                return true && Parse(ssn).Format(longFormat,ignoreSeparator) == ssn;
+                return Parse(ssn).Format(longFormat,ignoreSeparator) == ssn;
             }
             catch (PersonnummerException)
             {

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -165,6 +165,25 @@ namespace Personnummer
             }
         }
 
+        /// <summary>
+        /// Test a personal identity number to see if it is valid or not, and also checks if passed personal identity number is according to specified format
+        /// </summary>
+        /// <param name="ssn">Personal identity number to test.</param>
+        /// <param name="longFormat">If century should be included.</param>
+        /// <param name="ignoreSeparator">Whether the separator should be ignored.</param>
+        /// <returns>True if valid format, else false.</returns>
+        public static bool ValidFormat(string ssn, bool longFormat = false, bool ignoreSeparator = false)
+        {
+            try
+            {
+                return true && Parse(ssn).Format(longFormat,ignoreSeparator) == ssn;
+            }
+            catch (PersonnummerException)
+            {
+                return false;
+            }
+        }
+
         #region Static internal.
         private static readonly Regex regex = new Regex(@"^(\d{2}){0,1}(\d{2})(\d{2})(\d{2})([\+\-]?)((?!000)\d{3})(\d)$");
 

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,12 @@ class Test
     Personnummer.Valid("121212+1212")       // => True
     Personnummer.Valid("20121212-1212")     // => True
   }
+
+  public void TestValidationFormat()
+  {
+    Personnummer.ValidFormat("191212121212",longFormat:true,ignoreSeparator:true);     // => True
+    Personnummer.ValidFormat("20121212-1212",longFormat:true,ignoreSeparator:false);         // => True  
+  }
 }
 ```
 


### PR DESCRIPTION
…ed format (ValidFormat).

**Type of change**

- [x] New feature
- [ ] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Adds an function to validate format to what is expected i.e. personal identity number provided to function should be according to a specific format.

**Related issue**

<!-- Issue which this PR is connected to, if any. -->

**Motivation**

I could have done this by myself. But it feels strange to pull up and do some manual regex or string-matching just for checking format of personal identity number. Why should I then use a nuget-package in first place? If I need to add some logic anyway  (Okay not such a  big deal, probably a oneliner as an extension method, but anyways 😂). 
And maybe someone else could benefit from this function?

**Checklist**

- [ ] I have read the **CONTRIBUTING** document. (Could not find in repo)
- [ ] I have read and accepted the **Code of conduct**  (Could not find in repo)
- [x] Tests passes.
- [ ] Style lints passes. (dunno)
- [x] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
- [x] New tests added which covers the added code. (The dataset is added inline, because it seemed tedious atm to add to meta)
- [x] Documentation is updated.
<!-- - [ ] This PR includes breaking changes. -->
