### PR TITLE
fix(test): Fixed an issue where coordination number test would fail d…

### DIFF
--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -329,7 +329,7 @@ namespace Personnummer.Tests
         {
             var expect = data.LongFormat[..4];
             expect += data.LongFormat.Substring(4, 2);
-            expect += (int.Parse(data.LongFormat.Substring(6, 2)) - 60).ToString();
+            expect += (int.Parse(data.LongFormat.Substring(6, 2)) - 60).ToString("00");
 
             var pn = new Personnummer(data.LongFormat);
             Assert.Equal(expect, $"{pn.Date.Year:0000}{pn.Date.Month:00}{pn.Date.Day:00}");


### PR DESCRIPTION
…ue to 'expectaton' being wrongly parsed on int to string (no 00 format).

**Type of change**

- [X] Bug fix

**Description**

When parsing the "expected" value for dates on coordination numbers, any integer less than 10 would produce a single char value instead of double (i.e., 08 would be 8 instead of 08).

This fix takes care of that and makes the tests pass.

**Motivation**

Fixes the tests!

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.