### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2020 - Personnummer and Contributors
+Copyright (c) Personnummer and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See `Personnummer.Test/PersonnummerTest.cs` for more examples.
 ```
 MIT License
 
-Copyright (c) 2017-2019 - Personnummer and Contributors
+Copyright (c) Personnummer and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Remove year from mit license, it's optional and hard to remember to update so let's skip it :)