### PR TITLE
fix: calculate personnummer correctly before annual birthday

### DIFF
--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -24,7 +24,21 @@ namespace Personnummer
 
         public DateTime Date { get; private set; }
 
-        public int Age => DateTime.Now.Year - Date.Year;
+        public int Age
+        {
+            get
+            {
+                var now = DateTime.Now;
+                var age = now.Year - Date.Year;
+
+                if (now.Month >= Date.Month && now.Day > Date.Day)
+                {
+                    age--;
+                }
+
+                return age;
+            }
+        }
 
         public string Separator => Age >= 100 ? "+" : "-";
 


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [x] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Fixes an issue where the age is one year too much, if the person did not have had their birthday in the current year.

**Related issue**

**Motivation**

Less bugs, more happy people :)

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [ ] Style lints passes.
- [x] Documentation of new public methods exists.
<!-- The following are only needed if this is a new feature. -->
- [ ] New tests added which covers the added code
<!-- - [ ] Documentation is updated. -->
<!-- - [ ] This PR includes breaking changes. -->

**Notes**

- As you can see, I have __not__ added a unit test for the fix. The reason for that is that the code uses `DateTime.Now` which will make the tests for this test case break depending on if the birth date has already taken place during the current year or not. The proper fix would be to use [TimeProvider](https://learn.microsoft.com/en-us/dotnet/api/system.timeprovider?view=net-8.0) introduced in .NET 8, but I do not know the implications of that when targeting specific .NET versions and I do not have the time to look into it.
- `DateTime.Now` has another issue, as it takes the local time of the computer running on. Personal Numbers are given according to the Swedish time zone, so there might be some edge cases when a computer runs in a time zone which is considered a different day than in Sweden. Still, this PR improves the accuracy from up to 366 days of error to 1 day.
- I have used `var`. If you prefer the type instead, let me know and I will adjust the coding style.
