### PR TITLE
Updated project to build for .net 8 and 9. Updated ci to use .net 9.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,13 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    # Required for now, due to auto script not using dotnet 9 yet.
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          9.0.x
+
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '8.0.x' ]
+        dotnet: [ '9.0.x' ]
     name: Test dotnet ${{ matrix.dotnet-versions }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up dotnet.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
       - name: Build
         run: dotnet build --configuration Release Personnummer -p:VersionPrefix=${{ github.event.release.tag_name }}
       - name: Package

--- a/Personnummer.Tests/Personnummer.Tests.csproj
+++ b/Personnummer.Tests/Personnummer.Tests.csproj
@@ -4,9 +4,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
 
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Personnummer/Personnummer.csproj
+++ b/Personnummer/Personnummer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net7.0;netstandard2.1;net46;net47;net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Company>Personnummer</Company>
     <Authors>Johannes Tegnér, Personnummer Contributors</Authors>
     <Description>Verify Swedish personal identity numbers.</Description>
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicense>https://github.com/personnummer/csharp/blob/master/LICENSE</PackageLicense>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>12</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>(C) Personnummer &amp; Contributors</Copyright>
     <Title>Personnummer</Title>


### PR DESCRIPTION
**Type of change**

Target update, removes old dotnet versions and adds dotnet 9.

Note: This is a breaking change (as it no longer will support old dotnet versions).

**Related issue**

Closes #108 

**Motivation**

Sanitation.
Further, it allows us to use TimeProvider for tests, allowing us to fix #107 a lot easier.

**Checklist**

- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [ ] Tests passes.
- [x] Style lints passes.
- [x] Documentation of new public methods exists.
- [x] This PR includes breaking changes.
