### PR TITLE
Fix to "Age" tests.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,13 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
+    # Required for now, due to auto script not using dotnet 9 yet.
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          9.0.x
+
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '8.0.x' ]
+        dotnet: [ '9.0.x' ]
     name: Test dotnet ${{ matrix.dotnet-versions }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up dotnet.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '9.0.x'
       - name: Build
         run: dotnet build --configuration Release Personnummer -p:VersionPrefix=${{ github.event.release.tag_name }}
       - name: Package

--- a/Personnummer.Tests/CoordinationNumberTests.cs
+++ b/Personnummer.Tests/CoordinationNumberTests.cs
@@ -103,17 +103,19 @@ namespace Personnummer.Tests
         [ClassData(typeof(ValidCnDataProvider))]
         public void TestAgeCn(PersonnummerData ssn)
         {
+            var timeProvider = new TestTimeProvider();
+
             int day = int.Parse(ssn.LongFormat.Substring(ssn.LongFormat.Length - 6, 2)) - 60;
             string strDay = day < 10 ? $"0{day}" : day.ToString();
 
-            DateTime dt    = DateTime.ParseExact(ssn.LongFormat.Substring(0, ssn.LongFormat.Length - 6) + strDay, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None);
-            int      years = DateTime.Now.Year - dt.Year;
+            DateTime dt = DateTime.ParseExact(ssn.LongFormat.Substring(0, ssn.LongFormat.Length - 6) + strDay, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None);
+            int years = timeProvider.GetLocalNow().Year - dt.Year;
 
-            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedLong, new Personnummer.Options { AllowCoordinationNumber = true }).Age);
-            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedFormat, new Personnummer.Options { AllowCoordinationNumber = true }).Age);
-            Assert.Equal(years, Personnummer.Parse(ssn.LongFormat, new Personnummer.Options { AllowCoordinationNumber = true }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedLong, new Personnummer.Options { AllowCoordinationNumber = true, TimeProvider = timeProvider }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedFormat, new Personnummer.Options { AllowCoordinationNumber = true, TimeProvider = timeProvider }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.LongFormat, new Personnummer.Options { AllowCoordinationNumber = true, TimeProvider = timeProvider }).Age);
             // Du to age not being possible to fetch from >100 year short format without separator, we aught to check this here.
-            Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = true }).Age);
+            Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = true, TimeProvider = timeProvider }).Age);
         }
 
 

--- a/Personnummer.Tests/Personnummer.Tests.csproj
+++ b/Personnummer.Tests/Personnummer.Tests.csproj
@@ -4,9 +4,9 @@
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>9</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
 
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -80,14 +80,15 @@ namespace Personnummer.Tests
         [ClassData(typeof(ValidSsnDataProvider))]
         public void TestAge(PersonnummerData ssn)
         {
+            var timeProvider = new TestTimeProvider();
             DateTime dt = DateTime.ParseExact(ssn.LongFormat.Substring(0, ssn.LongFormat.Length - 4), "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None);
-            int years = DateTime.Now.Year - dt.Year;
+            int years = timeProvider.GetLocalNow().Year - dt.Year;
 
-            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedLong, new Personnummer.Options { AllowCoordinationNumber = false }).Age);
-            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedFormat, new Personnummer.Options { AllowCoordinationNumber = false }).Age);
-            Assert.Equal(years, Personnummer.Parse(ssn.LongFormat, new Personnummer.Options { AllowCoordinationNumber = false }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedLong, new Personnummer.Options { AllowCoordinationNumber = false, TimeProvider = timeProvider }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.SeparatedFormat, new Personnummer.Options { AllowCoordinationNumber = false, TimeProvider = timeProvider }).Age);
+            Assert.Equal(years, Personnummer.Parse(ssn.LongFormat, new Personnummer.Options { AllowCoordinationNumber = false, TimeProvider = timeProvider }).Age);
             // Du to age not being possible to fetch from >100 year short format without separator, we aught to check this here.
-            Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = false }).Age);
+            Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = false, TimeProvider = timeProvider }).Age);
         }
 
         [Theory]

--- a/Personnummer.Tests/TestTimeProvider.cs
+++ b/Personnummer.Tests/TestTimeProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Personnummer.Tests;
+
+/// <summary>
+/// TimeProvider which always returns the same date: 2025 01 01 00:00:01 with UTC timezone on local time.
+/// </summary>
+public class TestTimeProvider : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow()
+    {
+        return new DateTimeOffset(
+            new DateOnly(2025, 1, 1),
+            new TimeOnly(0,0,0, 1),
+            TimeSpan.Zero
+        );
+    }
+
+    public override TimeZoneInfo LocalTimeZone { get; } = TimeZoneInfo.Utc;
+}

--- a/Personnummer/Personnummer.csproj
+++ b/Personnummer/Personnummer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net7.0;netstandard2.1;net46;net47;net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Company>Personnummer</Company>
     <Authors>Johannes Tegnér, Personnummer Contributors</Authors>
     <Description>Verify Swedish personal identity numbers.</Description>
@@ -12,7 +12,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicense>https://github.com/personnummer/csharp/blob/master/LICENSE</PackageLicense>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>12</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>(C) Personnummer &amp; Contributors</Copyright>
     <Title>Personnummer</Title>


### PR DESCRIPTION
Note:

This PR is based on the #109 PR, which should be merged before this (even though the tests fails).

**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Fixes the issue where age tests report wrong due to a simplified check.
Still uses simple check, while the time is always 2025-01-01 00:00:01 UTC (with local timezone set to UTC), allowing the simplified calculation in the tests.

**Related issue**

Closes #107 

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] Documentation of new public methods exists.
