### PR TITLE
AB#112: Fixed a bug where Age returned 1 year less than expected.

### DIFF
--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -234,5 +234,15 @@ namespace Personnummer.Tests
                 }).Message
             );
         }
+
+        [Fact]
+        public void TestEdgeCasesAroundBirthday()
+        {
+            var timeProvider = new TestTimeProvider(); //TestTime is 2025-10-05 
+            Assert.Equal(18, new Personnummer("20071004-3654", new Personnummer.Options() {TimeProvider = timeProvider} ).Age); // Had birthday yesterday
+            Assert.Equal(18, new Personnummer("20071005-3653", new Personnummer.Options() {TimeProvider = timeProvider} ).Age); // Birthday today
+            Assert.Equal(17, new Personnummer("20071006-3652", new Personnummer.Options() {TimeProvider = timeProvider} ).Age); // Upcoming Birthday tomorrow
+        }
+       
     }
 }

--- a/Personnummer.Tests/TestTimeProvider.cs
+++ b/Personnummer.Tests/TestTimeProvider.cs
@@ -10,7 +10,7 @@ public class TestTimeProvider : TimeProvider
     public override DateTimeOffset GetUtcNow()
     {
         return new DateTimeOffset(
-            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 10, 5),
             new TimeOnly(0,0,0, 1),
             TimeSpan.Zero
         );

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -39,8 +39,11 @@ namespace Personnummer
             {
                 var now = _options.TimeProvider.GetLocalNow();
                 var age = now.Year - Date.Year;
+                
+                var hadBirthdayThisYear = (now.Month > Date.Month) ||  
+                                        (now.Month == Date.Month && now.Day >= Date.Day);
 
-                if (now.Month >= Date.Month && now.Day > Date.Day)
+                if (!hadBirthdayThisYear)
                 {
                     age--;
                 }


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

This fixes the Age property to return the correct age.  See linked Issue for more details.


I have included a new test 'TestEdgeCasesAroundBirthday' that demonstrates the faulty behaviour with the previous implementation, and verifies the correct behaviour with the new implementation.

Note:  
If we just change the Age implementation we will  break all the tests for 'TestAge'.
However, It's my understanding that these tests are actually faulty and expects the wrong age. I.e the second testdata gets '200002292399' as input SSN and expects that person to be '25' years old.. that however is wrong since the 'TestTimeProvider' returns '2025-01-01'. This person has not yet had his birthday this year and therfor is 24 years old. All the inputdata for this test has the same issue. 

I "solved" it by changing so that 'TestTimeProvider' returns 2025-10-05. Then all data for the tests has actually had their birthday, and it gives 'TestEdgeCasesAroundBirthday' an opportunity to check edgecases around the birthdays.

If I have misunderstood the previous tests or made wrong assumptions, let me know and I can try to fix it 😃 



**Related issue**

https://github.com/personnummer/csharp/issues/112

**Motivation**

To hopefully make things better 😄 

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [ ] Documentation of new public methods exists.
- [X] New tests added which covers the added code.
