### PR TITLE
Readd netstandard2.1, net7, net48 and net47.

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -9,16 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '9.0.x' ]
-    name: Test dotnet ${{ matrix.dotnet-versions }}
+    name: Test dotnet
     steps:
       - uses: actions/checkout@v4
-      - name: Set up dotnet.
+      - name: Set up dotnet 7.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: '7.0.x'
+      - name: Set up dotnet 9.
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
       - name: Build
         run: dotnet build
       - name: Run test suite

--- a/Personnummer.Tests/CoordinationNumberTests.cs
+++ b/Personnummer.Tests/CoordinationNumberTests.cs
@@ -99,6 +99,7 @@ namespace Personnummer.Tests
             }));
         }
 
+#if NET8_0_OR_GREATER
         [Theory]
         [ClassData(typeof(ValidCnDataProvider))]
         public void TestAgeCn(PersonnummerData ssn)
@@ -117,7 +118,7 @@ namespace Personnummer.Tests
             // Du to age not being possible to fetch from >100 year short format without separator, we aught to check this here.
             Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = true, TimeProvider = timeProvider }).Age);
         }
-
+#endif
 
         [Theory]
         [ClassData(typeof(ValidCnDataProvider))]

--- a/Personnummer.Tests/Personnummer.Tests.csproj
+++ b/Personnummer.Tests/Personnummer.Tests.csproj
@@ -6,15 +6,13 @@
 
     <LangVersion>latestmajor</LangVersion>
 
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.core" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.utility" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Personnummer.Tests/PersonnummerTests.cs
+++ b/Personnummer.Tests/PersonnummerTests.cs
@@ -76,6 +76,7 @@ namespace Personnummer.Tests
         }
 
 
+#if NET8_0_OR_GREATER // Requires TimeProvider.
         [Theory]
         [ClassData(typeof(ValidSsnDataProvider))]
         public void TestAge(PersonnummerData ssn)
@@ -90,6 +91,7 @@ namespace Personnummer.Tests
             // Du to age not being possible to fetch from >100 year short format without separator, we aught to check this here.
             Assert.Equal(years > 99 ? years - 100 : years, Personnummer.Parse(ssn.ShortFormat, new Personnummer.Options { AllowCoordinationNumber = false, TimeProvider = timeProvider }).Age);
         }
+#endif
 
         [Theory]
         [ClassData(typeof(ValidSsnDataProvider))]

--- a/Personnummer.Tests/TestTimeProvider.cs
+++ b/Personnummer.Tests/TestTimeProvider.cs
@@ -2,19 +2,25 @@
 
 namespace Personnummer.Tests;
 
+#if NET8_0_OR_GREATER
+
 /// <summary>
 /// TimeProvider which always returns the same date: 2025 01 01 00:00:01 with UTC timezone on local time.
 /// </summary>
 public class TestTimeProvider : TimeProvider
 {
+    internal DateTimeOffset Now { get; set; } = new(
+        new DateOnly(2025, 1, 5),
+        new TimeOnly(0, 0, 0, 1),
+        TimeSpan.Zero
+    );
+
     public override DateTimeOffset GetUtcNow()
     {
-        return new DateTimeOffset(
-            new DateOnly(2025, 1, 1),
-            new TimeOnly(0,0,0, 1),
-            TimeSpan.Zero
-        );
+        return Now;
     }
 
     public override TimeZoneInfo LocalTimeZone { get; } = TimeZoneInfo.Utc;
 }
+
+#endif

--- a/Personnummer/Personnummer.cs
+++ b/Personnummer/Personnummer.cs
@@ -19,6 +19,7 @@ namespace Personnummer
 
             public bool AllowInterimNumber { get; set; } = false;
 
+#if (NET8_0_OR_GREATER)
             /// <summary>
             /// TimeProvider to use in calculations which are time dependent.<br/>
             /// Uses `GetLocalNow` method.
@@ -26,7 +27,12 @@ namespace Personnummer
             /// Defaults to System provider.
             /// </remarks>
             /// </summary>
-            public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+            public TimeProvider TimeProvider { private get; init; } = TimeProvider.System;
+
+            internal DateTimeOffset DateTimeNow => TimeProvider.GetLocalNow();
+#else
+            internal DateTimeOffset DateTimeNow => DateTimeOffset.Now;
+#endif
         }
 
         #region Fields and Properties
@@ -37,10 +43,10 @@ namespace Personnummer
         {
             get
             {
-                var now = _options.TimeProvider.GetLocalNow();
+                var now = _options.DateTimeNow;
                 var age = now.Year - Date.Year;
 
-                if (now.Month >= Date.Month && now.Day > Date.Day)
+                if (now.Month >= Date.Month && now.Day >= Date.Day)
                 {
                     age--;
                 }
@@ -124,7 +130,7 @@ namespace Personnummer
             }
             else
             {
-                int born = TimeProvider.System.GetLocalNow().Year - int.Parse(decade);
+                int born = _options.DateTimeNow.Year - int.Parse(decade);
                 if (groups["separator"].Value.Length != 0 && groups["separator"].Value == "+")
                 {
                     born -= 100;

--- a/Personnummer/Personnummer.csproj
+++ b/Personnummer/Personnummer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1;net47;net48</TargetFrameworks>
     <Company>Personnummer</Company>
     <Authors>Johannes Tegnér, Personnummer Contributors</Authors>
     <Description>Verify Swedish personal identity numbers.</Description>


### PR DESCRIPTION
This PR re-adds older net versions (we can remove on next major release).
Keeps TimeProvider intact for net8+ while older versions will ignore it with a `#if` directive.