### PR TITLE
Drop net7 support (eol).

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -12,10 +12,10 @@ jobs:
     name: Test dotnet
     steps:
       - uses: actions/checkout@v5
-      - name: Set up dotnet 7.
+      - name: Set up dotnet 8.
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
       - name: Set up dotnet 9.
         uses: actions/setup-dotnet@v4
         with:

--- a/Personnummer.Tests/Personnummer.Tests.csproj
+++ b/Personnummer.Tests/Personnummer.Tests.csproj
@@ -6,12 +6,11 @@
 
     <LangVersion>latestmajor</LangVersion>
 
-    <TargetFrameworks>net9.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" Condition=" '$(TargetFramework)'=='net9.0' "/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition=" '$(TargetFramework)'=='net7.0' "/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Personnummer/Personnummer.csproj
+++ b/Personnummer/Personnummer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0;net9.0;netstandard2.1;net47;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.1;net47;net48</TargetFrameworks>
     <Company>Personnummer</Company>
     <Authors>Johannes Tegnér, Personnummer Contributors</Authors>
     <Description>Verify Swedish personal identity numbers.</Description>


### PR DESCRIPTION
**Description**

Dropps support for dotnet7 (end of life a while back).
Tests are now ran for dotnet 8 and 9 (can discuss if this is useful or just stick to latest).

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
